### PR TITLE
5 create equivalent width refine

### DIFF
--- a/src/aflak_primitives/src/lib.rs
+++ b/src/aflak_primitives/src/lib.rs
@@ -623,12 +623,7 @@ fn run_create_equivalent_width(
 
 fn run_convert_to_logscale(i1: &WcsArray2) -> Result<IOValue, IOErr> {
     let i1_arr = i1.scalar();
-    let mut min: f32 = std::f32::MAX;
-    for i in i1_arr {
-        min = min.min(*i);
-    }
-    // TODO: What if min is negative? All will be shifted up!
-    let out = i1_arr.map(|v| (v + min.abs() + 1.0).log10());
+    let out = i1_arr.map(|v| v.log10());
     // FIXME: Unit support
     Ok(IOValue::Image2d(WcsArray2::from_array(Dimensioned::new(
         out,

--- a/src/aflak_primitives/src/lib.rs
+++ b/src/aflak_primitives/src/lib.rs
@@ -206,8 +206,8 @@ Third output contains (b - a)",
                 "Create Equivalent-Width map from off-band and on-band.
 Parameters i1, i2, onband-width, min.
 Compute value = (i1 - i2) *fl / i1. if abs(value) > max, value changes to 0.",
-                create_equivalent_width<IOValue, IOErr>(i1: Image2d, i2: Image2d, fl: Float = 1.0, max: Float = ::std::f32::INFINITY) -> Image2d {
-                    vec![run_create_equivalent_width(i1, i2, *fl, *max)]
+                create_equivalent_width<IOValue, IOErr>(i1: Image2d, i2: Image2d, fl: Float = 1.0, max: Float = ::std::f32::INFINITY, is_emission: Bool = false) -> Image2d {
+                    vec![run_create_equivalent_width(i1, i2, *fl, *max, *is_emission)]
                 }
             ),
             cake_transform!(
@@ -607,11 +607,12 @@ fn run_create_equivalent_width(
     i2: &WcsArray2,
     fl: f32,
     max: f32,
+    is_emission: bool,
 ) -> Result<IOValue, IOErr> {
     let i1_arr = i1.scalar();
     let i2_arr = i2.scalar();
-    let out = (i1_arr - i2_arr) * fl / i1_arr;
-    let result = out.map(|v| if v.abs() > max { 0.0 } else { *v });
+    let out = (i1_arr - i2_arr) * fl / i1_arr * (if is_emission { -1.0 } else { 1.0 });
+    let result = out.map(|v| if *v > max { 0.0 } else { *v });
 
     // FIXME: Unit support
     Ok(IOValue::Image2d(WcsArray2::from_array(Dimensioned::new(

--- a/src/aflak_primitives/src/lib.rs
+++ b/src/aflak_primitives/src/lib.rs
@@ -215,6 +215,20 @@ if value > max, value changes to 0.",
                 "Convert to log-scale. Parameter: 2D image i. Compute log(i).",
                 convert_to_logscale<IOValue, IOErr>(i1: Image2d) -> Image2d {
                     vec![run_convert_to_logscale(i1)]
+            cake_transform!(
+                "Image's min and max value. Parameter: 2D image i.
+Compute v_min(first), v_max(second)",
+                image_min_max<IOValue, IOErr>(i1: Image2d) -> Float, Float {
+                    let mut min = std::f32::MAX;
+                    let mut max = std::f32::MIN;
+                    let i1_arr = i1.scalar();
+
+                    for i in i1_arr {
+                        min = min.min(*i);
+                        max = max.max(*i);
+                    }
+
+                    vec![Ok(IOValue::Float(min)), Ok(IOValue::Float(max))]
                 }
             ),
             cake_transform!(

--- a/src/aflak_primitives/src/lib.rs
+++ b/src/aflak_primitives/src/lib.rs
@@ -196,7 +196,7 @@ Compute off_ratio = 1 - (z - z1) / (z2 - z1), off_ratio_2 = 1 - (z2 - z) / (z2 -
 Compute (Sum[k, {a, b}]image[k]) / (b - a). image[k] is k-th slice of 3D-fits image.
 Second output contains (a + b) / 2
 Third output contains (b - a)",
-                average<IOValue, IOErr>(image: Image3d, start: Integer = 0, end: Integer = 1) -> Image2d, Float {
+                average<IOValue, IOErr>(image: Image3d, start: Integer = 0, end: Integer = 1) -> Image2d, Float, Float {
                     let middle = (*start as f32 + *end as f32) / 2.0;
                     let width = *end as f32 - *start as f32;
                     vec![run_average(image, *start, *end), Ok(IOValue::Float(middle)), Ok(IOValue::Float(width))]

--- a/src/aflak_primitives/src/lib.rs
+++ b/src/aflak_primitives/src/lib.rs
@@ -204,8 +204,9 @@ Third output contains (b - a)",
             ),
             cake_transform!(
                 "Create Equivalent-Width map from off-band and on-band.
-Parameters i1, i2, onband-width, min.
-Compute value = (i1 - i2) *fl / i1. if abs(value) > max, value changes to 0.",
+Parameters i1, i2, onband-width, min, is_emission.
+Compute value = (i1 - i2) * fl / i1 (if is_emission is true, the sign of this value turns over).
+if value > max, value changes to 0.",
                 create_equivalent_width<IOValue, IOErr>(i1: Image2d, i2: Image2d, fl: Float = 1.0, max: Float = ::std::f32::INFINITY, is_emission: Bool = false) -> Image2d {
                     vec![run_create_equivalent_width(i1, i2, *fl, *max, *is_emission)]
                 }

--- a/src/src/templates.rs
+++ b/src/src/templates.rs
@@ -206,6 +206,7 @@ pub fn show_equivalent_width<P: AsRef<Path>>(path: P) -> Cursor<String> {
                     None,
                     Some(Float(20)),
                     Some(Float(10000000000)),
+                    Some(Bool(true)),
                 ],
             )),
             ((22), (


### PR DESCRIPTION
等価幅の作成にBoolノードを組み込み、輝線/暗線の選択をできるようにしました。
また、logをとる際の不要な計算を削除しました。