### PR TITLE
Fix deserialization error on paths containing characters that must be escaped

### DIFF
--- a/src/src/templates.rs
+++ b/src/src/templates.rs
@@ -506,4 +506,14 @@ mod test {
         let editor = NodeEditor::from_export_buf(buf, transformations, MyConstantEditor);
         assert!(editor.is_ok());
     }
+
+    #[test]
+    fn import_with_windows_style_paths() {
+        let transformations_ref = primitives::TRANSFORMATIONS.iter().collect::<Vec<_>>();
+        let transformations = transformations_ref.as_slice();
+
+        let buf = show_equivalent_width(r"C:\path\to\fits\file.fits");
+        let editor = NodeEditor::from_export_buf(buf, transformations, MyConstantEditor);
+        assert!(editor.is_ok());
+    }
 }

--- a/src/src/templates.rs
+++ b/src/src/templates.rs
@@ -50,7 +50,7 @@ pub fn show_frame_and_wave<P: AsRef<Path>>(path: P) -> Cursor<String> {
                 ],
             )),
             ((1), (
-                t: Constant(Path("{}")),
+                t: Constant(Path({:?})),
                 input_defaults: [
                 ],
             )),
@@ -251,7 +251,7 @@ pub fn show_equivalent_width<P: AsRef<Path>>(path: P) -> Cursor<String> {
                 ],
             )),
             ((1), (
-                t: Constant(Path("{}")),
+                t: Constant(Path({:?})),
                 input_defaults: [
                 ],
             )),


### PR DESCRIPTION
Include a test that reproduces the error, along with the (simple) fix.

Fix #25 