### PR TITLE
Print stack trace in output window

### DIFF
--- a/src/aflak_cake/src/dst/compute.rs
+++ b/src/aflak_cake/src/dst/compute.rs
@@ -97,7 +97,14 @@ where
             for result in &results {
                 match result {
                     Ok(ok) => op.feed(&**ok),
-                    Err(e) => return vec![Err((*e).clone()); output_count],
+                    Err(e) => {
+                        let error_stack = DSTError::ErrorStack {
+                            cause: e.clone(),
+                            t_idx,
+                            t_name: t.name(),
+                        };
+                        return vec![Err(Arc::new(error_stack)); output_count];
+                    }
                 }
             }
             let mut out = Vec::with_capacity(output_count);


### PR DESCRIPTION
エラーが発生するとき、stack traceをプリントする。
@dabokun 軽くチェックをお願いします。

次回のマージリクエストでprimitivesの前提条件のエラー管理を簡単化します。

![image](https://user-images.githubusercontent.com/14120117/50276407-394cb280-0485-11e9-8efa-2d8379cb7d9d.png)
