### PR TITLE
[primitives] Helper macros for precondition checks

### DIFF
--- a/src/aflak_primitives/src/lib.rs
+++ b/src/aflak_primitives/src/lib.rs
@@ -809,13 +809,7 @@ fn run_argminmax(image: &WcsArray, start: i64, end: i64, is_min: bool) -> Result
 
     let image_val = image.scalar();
 
-    let ndim = image_val.ndim();
-    if ndim < 1 {
-        return Err(IOErr::UnexpectedInput(format!(
-            "Cannot compute {}-Dimensional array",
-            ndim
-        )));
-    }
+    precheck!(image_val.ndim() > 0, "'im' is a 0-dimensional array")?;
     let len_of_axis0 = image_val.len_of(Axis(0));
     if end > len_of_axis0 {
         return Err(IOErr::UnexpectedInput(format!(
@@ -873,13 +867,7 @@ fn run_centroid(image: &WcsArray, start: i64, end: i64) -> Result<IOValue, IOErr
 
     let image_val = image.scalar();
 
-    let ndim = image_val.ndim();
-    if ndim < 1 {
-        return Err(IOErr::UnexpectedInput(format!(
-            "Cannot compute {}-Dimensional array",
-            ndim
-        )));
-    }
+    precheck!(image_val.ndim() > 0, "'im' is a 0-dimensional array")?;
     let len_of_axis0 = image_val.len_of(Axis(0));
     if end > len_of_axis0 {
         return Err(IOErr::UnexpectedInput(format!(

--- a/src/aflak_primitives/src/lib.rs
+++ b/src/aflak_primitives/src/lib.rs
@@ -708,14 +708,7 @@ fn run_linear_composition(
     coef1: f32,
     coef2: f32,
 ) -> Result<IOValue, IOErr> {
-    let i1_dim = i1.scalar().dim();
-    let i2_dim = i2.scalar().dim();
-    if i1_dim != i2_dim {
-        return Err(IOErr::UnexpectedInput(format!(
-            "linear_composition: Cannot compose arrays of different dimensions (first array has dimension {:?}, while second array has dimension {:?}",
-            i1_dim, i2_dim
-        )));
-    }
+    are_same_dim!(i1, i2)?;
     let out = i1 * coef1 + i2 * coef2;
     Ok(IOValue::Image(out))
 }

--- a/src/aflak_primitives/src/lib.rs
+++ b/src/aflak_primitives/src/lib.rs
@@ -744,6 +744,7 @@ where
 {
     let start = try_into_unsigned!(start)?;
     let end = try_into_unsigned!(end)?;
+    precheck!(start < end)?;
 
     let image_val = image.scalar();
     let frame_cnt = if let Some(frame_cnt) = image_val.dim().as_array_view().first() {
@@ -758,12 +759,6 @@ where
         return Err(IOErr::UnexpectedInput(format!(
             "end higher than input image's frame count ({} >= {})",
             end, frame_cnt
-        )));
-    }
-    if start >= end {
-        return Err(IOErr::UnexpectedInput(format!(
-            "start higher than end ({} >= {})",
-            start, end
         )));
     }
 
@@ -810,15 +805,9 @@ fn run_minmax(image: &WcsArray, start: i64, end: i64, is_min: bool) -> Result<IO
 fn run_argminmax(image: &WcsArray, start: i64, end: i64, is_min: bool) -> Result<IOValue, IOErr> {
     let start = try_into_unsigned!(start)?;
     let end = try_into_unsigned!(end)?;
+    precheck!(start < end)?;
 
     let image_val = image.scalar();
-
-    if start >= end {
-        return Err(IOErr::UnexpectedInput(format!(
-            "start higher than end ({} >= {})",
-            start, end
-        )));
-    }
 
     let ndim = image_val.ndim();
     if ndim < 1 {
@@ -880,15 +869,9 @@ fn run_argminmax(image: &WcsArray, start: i64, end: i64, is_min: bool) -> Result
 fn run_centroid(image: &WcsArray, start: i64, end: i64) -> Result<IOValue, IOErr> {
     let start = try_into_unsigned!(start)?;
     let end = try_into_unsigned!(end)?;
+    precheck!(start < end)?;
 
     let image_val = image.scalar();
-
-    if start >= end {
-        return Err(IOErr::UnexpectedInput(format!(
-            "start higher than end ({} >= {})",
-            start, end
-        )));
-    }
 
     let ndim = image_val.ndim();
     if ndim < 1 {

--- a/src/aflak_primitives/src/precond.rs
+++ b/src/aflak_primitives/src/precond.rs
@@ -1,0 +1,15 @@
+/// Try to convert an integer into a usize.
+/// Return a `Result<usize, IOErr>`.
+macro_rules! try_into_unsigned {
+    ($value: ident) => {
+        if $value >= 0 {
+            Ok($value as usize)
+        } else {
+            Err($crate::IOErr::UnexpectedInput(format!(
+                "'{}' must be positive, but got {}",
+                stringify!($value),
+                $value
+            )))
+        }
+    };
+}

--- a/src/aflak_primitives/src/precond.rs
+++ b/src/aflak_primitives/src/precond.rs
@@ -13,3 +13,22 @@ macro_rules! try_into_unsigned {
         }
     };
 }
+
+/// Check that a custom condition is fulfilled.
+macro_rules! precheck {
+    ($start: ident $op :tt $end: ident) => {
+        if $start $op $end {
+            Ok(())
+        } else {
+            Err($crate::IOErr::UnexpectedInput(format!(
+                "Expected {} {} {}, but got {} {} {}",
+                stringify!($start),
+                stringify!($op),
+                stringify!($end),
+                $start,
+                stringify!($op),
+                $end,
+            )))
+        }
+    };
+}

--- a/src/aflak_primitives/src/precond.rs
+++ b/src/aflak_primitives/src/precond.rs
@@ -78,3 +78,19 @@ macro_rules! is_sliceable {
         })
     };
 }
+
+/// Check that two WcsArray have the same dimensions
+macro_rules! are_same_dim {
+    ($wcs_array1: ident, $wcs_array2: ident) => {{
+        let i1_dim = $wcs_array1.scalar().dim();
+        let i2_dim = $wcs_array2.scalar().dim();
+        if i1_dim == i2_dim {
+            Ok(())
+        } else {
+            Err(IOErr::UnexpectedInput(format!(
+                "Cannot compose images of different dimensions ('{}' has dimension {:?}, while '{}' has dimension {:?})",
+                stringify!($wcs_array1), i1_dim, stringify!($wcs_array2), i2_dim,
+            )))
+        }
+    }};
+}

--- a/src/aflak_primitives/src/precond.rs
+++ b/src/aflak_primitives/src/precond.rs
@@ -31,4 +31,11 @@ macro_rules! precheck {
             )))
         }
     };
+    ($cond: expr, $($arg:tt)*) => {
+        if $cond {
+            Ok(())
+        } else {
+            Err($crate::IOErr::UnexpectedInput(format!($($arg)*)))
+        }
+    };
 }


### PR DESCRIPTION
Define convenience macros to reduce boilerplate. Code should be self-explanatory.

Let's use those convenience macros for precondition checks from now on.