### PR TITLE
[aflak] Replace the use of deprecated items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.28.0
+  - 1.33.0
 os:
   - linux
   - osx

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ for a better experience. 3000-pixel is even better!
 
 ## Build from source
 
-Minimum Rust version: 1.28.0.
+Minimum Rust version: 1.33.0.
 
 Install the rust toolchain with [rustup](https://rustup.rs/).
 You will need a working C & C++ environment to install from sources.

--- a/src/imgui_glium_support/src/clipboard_support.rs
+++ b/src/imgui_glium_support/src/clipboard_support.rs
@@ -5,7 +5,7 @@ use clipboard::ClipboardProvider;
 
 use imgui::{Clipboard, ImGui};
 
-pub fn setup(imgui: &mut ImGui) -> Result<(), Box<error::Error>> {
+pub fn setup(imgui: &mut ImGui) -> Result<(), Box<dyn error::Error>> {
     let ctx: ClipboardContext = ClipboardProvider::new()?;
     imgui.prepare_clipboard::<ClipboardImpl>(ctx);
     Ok(())

--- a/src/imgui_glium_support/src/glutin_support.rs
+++ b/src/imgui_glium_support/src/glutin_support.rs
@@ -80,7 +80,7 @@ pub fn handle_mouse_button_state(imgui: &mut ImGui, button: MouseButton, state: 
         MouseButton::Left => states[0] = state_bool,
         MouseButton::Right => states[1] = state_bool,
         MouseButton::Middle => states[2] = state_bool,
-        MouseButton::Other(idx @ 0...4) => states[idx as usize] = state_bool,
+        MouseButton::Other(idx @ 0..=4) => states[idx as usize] = state_bool,
         _ => (),
     }
     imgui.set_mouse_down(states);

--- a/src/node_editor/src/lib.rs
+++ b/src/node_editor/src/lib.rs
@@ -38,7 +38,7 @@ pub struct NodeEditor<T: 'static, E: 'static> {
     cache: cake::Cache<T, cake::compute::ComputeError<E>>,
     macros: cake::macros::MacroManager<'static, T, E>,
     layout: NodeEditorLayout<T, E>,
-    error_stack: Vec<Box<error::Error>>,
+    error_stack: Vec<Box<dyn error::Error>>,
     success_stack: Vec<ImString>,
 
     nodes_edit: Vec<InnerNodeEditor<T, E>>,

--- a/src/src/aflak.rs
+++ b/src/src/aflak.rs
@@ -19,7 +19,7 @@ pub struct Aflak {
     node_editor: AflakNodeEditor,
     layout_engine: LayoutEngine,
     output_windows: HashMap<OutputId, OutputWindow>,
-    error_alerts: Vec<Box<error::Error>>,
+    error_alerts: Vec<Box<dyn error::Error>>,
 }
 
 impl Aflak {

--- a/src/src/build.rs
+++ b/src/src/build.rs
@@ -31,7 +31,7 @@ fn main() {
 // https://github.com/rust-lang-nursery/rustup.rs/blob/dd51ab0/build.rs
 fn commit_info() -> String {
     match (commit_hash(), commit_date()) {
-        (Ok(hash), Ok(date)) => format!(" ({} {})", hash.trim_right(), date),
+        (Ok(hash), Ok(date)) => format!(" ({} {})", hash.trim_end(), date),
         _ => String::new(),
     }
 }

--- a/src/src/main.rs
+++ b/src/src/main.rs
@@ -94,7 +94,7 @@ fn path_clean_up(path: Option<&str>, default: &str) -> PathBuf {
     path.canonicalize().unwrap_or(path)
 }
 
-fn open_buffer(matches: &clap::ArgMatches) -> Result<Box<Read>, io::Error> {
+fn open_buffer(matches: &clap::ArgMatches) -> Result<Box<dyn Read>, io::Error> {
     let fits = matches.value_of("fits");
     let fits_path = path_clean_up(fits, "file.fits");
     if let Some(template_name) = matches.value_of("template") {

--- a/src/src/output_window/menu_bar.rs
+++ b/src/src/output_window/menu_bar.rs
@@ -53,7 +53,7 @@ pub trait MenuBar {
         &self,
         ctx: OutputWindowCtx<'ui, '_, '_, '_, '_, '_, F>,
         window: Window<'ui, '_>,
-    ) -> Vec<Box<error::Error>>
+    ) -> Vec<Box<dyn error::Error>>
     where
         F: glium::backend::Facade,
     {
@@ -76,8 +76,8 @@ pub trait MenuBar {
         ui: &Ui,
         output: OutputId,
         window: &mut OutputWindow,
-    ) -> Vec<Box<error::Error>> {
-        let mut errors: Vec<Box<error::Error>> = vec![];
+    ) -> Vec<Box<dyn error::Error>> {
+        let mut errors: Vec<Box<dyn error::Error>> = vec![];
 
         let mut output_saved_success_popup = false;
         ui.menu_bar(|| {

--- a/src/src/output_window/mod.rs
+++ b/src/src/output_window/mod.rs
@@ -38,7 +38,7 @@ impl OutputWindow {
         node_editor: &mut AflakNodeEditor,
         gl_ctx: &F,
         textures: &mut Textures,
-    ) -> Vec<Box<error::Error>>
+    ) -> Vec<Box<dyn error::Error>>
     where
         F: glium::backend::Facade,
     {


### PR DESCRIPTION
警告が出る記法を訂正しました。