### PR TITLE
Fix crash on system with small stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,10 @@ jobs:
         - cargo fmt --version
       script:
         - cargo fmt --all -- --check
+    - stage: size-check
+      rust: nightly
+      install:
+        - cargo install print-type-sizes
+        - print-type-sizes --version
+      script:
+        - print-type-sizes --max-size 100000

--- a/src/aflak_plot/src/imshow/lut.rs
+++ b/src/aflak_plot/src/imshow/lut.rs
@@ -12,7 +12,7 @@ pub struct ColorLUT {
     /// Linear gradient
     /// Takes a series of color stops that indicate how to interpolate between the colors
     gradient: Vec<(f32, [u8; 3])>,
-    lut: [[u8; 3]; LUT_SIZE],
+    lut: Box<[[u8; 3]; LUT_SIZE]>,
     lims: (f32, f32),
 }
 
@@ -114,7 +114,7 @@ impl ColorLUT {
         }
         let mut color_lut = ColorLUT {
             gradient: vec,
-            lut: [[0; 3]; LUT_SIZE],
+            lut: Box::new([[0; 3]; LUT_SIZE]),
             lims: (0.0, 1.0),
         };
         color_lut.lut_init();


### PR DESCRIPTION
Large types may overflow the stack on some systems with a smaller stack (e.g. Windows 10).
I put a Box around a very big array, so that the array is now store on the heap.

I added a check in the CI (2156820) so that it fails if any type is bigger than 100kB, so that the same mistake will be caught in the future.

@dabokun Can you check that this patch does not crash on windows?

Fix #64 