### PR TITLE
Transition to Rust 2018 edition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "imgui-rs"]
-	path = imgui-rs
-	url = https://github.com/malikolivier/imgui-rs.git

--- a/README.md
+++ b/README.md
@@ -67,12 +67,10 @@ cargo install --force --git https://github.com/aflak-vis/aflak aflak
 ### Slower install
 
 Clone the git repository.
-You will need to initialize the git submodules.
 
 ```sh
 git clone https://github.com/aflak-vis/aflak
 cd aflak/src
-git submodule update --init --recursive
 cargo install --path .
 ```
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -3,6 +3,7 @@ name = "aflak"
 version = "0.0.4-pre"
 authors = ["Malik Olivier Boussejra <malik@boussejra.com>"]
 description = "Advanced Framework for Learning Astrophysical Knowledge"
+edition = "2018"
 license = "GPL-3.0-only"
 homepage = "https://github.com/aflak-vis/aflak"
 repository = "https://github.com/aflak-vis/aflak"

--- a/src/aflak_cake/Cargo.toml
+++ b/src/aflak_cake/Cargo.toml
@@ -3,6 +3,7 @@ name = "aflak_cake"
 version = "0.0.3"
 authors = ["Malik Olivier Boussejra <malik@boussejra.com>"]
 description = "Computational mAKE: Manage a graph of interdependent functions"
+edition = "2018"
 license = "GPL-3.0-only"
 
 [dependencies]

--- a/src/aflak_cake/src/cache.rs
+++ b/src/aflak_cake/src/cache.rs
@@ -5,8 +5,8 @@ use std::sync::{
 use std::thread;
 use std::time::Instant;
 
-use dst::{Output, TransformIdx};
-use timed::Timed;
+use crate::dst::{Output, TransformIdx};
+use crate::timed::Timed;
 
 use chashmap::CHashMap;
 

--- a/src/aflak_cake/src/dst/build.rs
+++ b/src/aflak_cake/src/dst/build.rs
@@ -6,10 +6,12 @@ use boow::Bow;
 use variant_name::VariantName;
 
 use super::super::ConvertibleVariants;
-use dst::node::{Node, NodeId};
-use dst::{DSTError, Input, InputDefaultsMut, InputList, Output, OutputId, TransformIdx, DST};
-use dst::{MetaTransform, TransformAndDefaults};
-use transform::Transform;
+use crate::dst::node::{Node, NodeId};
+use crate::dst::{
+    DSTError, Input, InputDefaultsMut, InputList, Output, OutputId, TransformIdx, DST,
+};
+use crate::dst::{MetaTransform, TransformAndDefaults};
+use crate::transform::Transform;
 
 impl<'t, T: 't, E: 't> DST<'t, T, E>
 where

--- a/src/aflak_cake/src/dst/compute.rs
+++ b/src/aflak_cake/src/dst/compute.rs
@@ -9,11 +9,11 @@ use boow::Bow;
 use rayon;
 
 use super::super::ConvertibleVariants;
-use cache::{Cache, CacheRef};
-use dst::{Input, Output, OutputId, TransformIdx, DST};
-use future::Task;
-use timed::Timed;
-use transform::{ArgumentError, CallError};
+use crate::cache::{Cache, CacheRef};
+use crate::dst::{Input, Output, OutputId, TransformIdx, DST};
+use crate::future::Task;
+use crate::timed::Timed;
+use crate::transform::{ArgumentError, CallError};
 use variant_name::VariantName;
 
 /// The successful result of a computation.

--- a/src/aflak_cake/src/dst/iterators.rs
+++ b/src/aflak_cake/src/dst/iterators.rs
@@ -3,10 +3,10 @@ use std::ops;
 use std::slice;
 use std::vec;
 
-use dst::node::{Node, NodeId};
-use dst::MetaTransform;
-use dst::{Input, InputList, InputSlot, Output, OutputId, TransformIdx, DST};
-use transform::Transform;
+use crate::dst::node::{Node, NodeId};
+use crate::dst::MetaTransform;
+use crate::dst::{Input, InputList, InputSlot, Output, OutputId, TransformIdx, DST};
+use crate::transform::Transform;
 use variant_name::VariantName;
 
 impl<'t, T: 't, E: 't> DST<'t, T, E> {

--- a/src/aflak_cake/src/dst/mod.rs
+++ b/src/aflak_cake/src/dst/mod.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use std::fmt;
 use std::time::Instant;
 
-use transform::{Algorithm, Transform};
+use crate::transform::{Algorithm, Transform};
 use variant_name::VariantName;
 
 mod build;
@@ -295,7 +295,7 @@ pub enum DSTError {
 
 impl fmt::Display for DSTError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use DSTError::*;
+        use crate::DSTError::*;
 
         match self {
             InvalidInput(s) => write!(f, "Invalid input! {}", s),

--- a/src/aflak_cake/src/dst/node.rs
+++ b/src/aflak_cake/src/dst/node.rs
@@ -1,5 +1,5 @@
-use dst::{Output, OutputId, TransformIdx};
-use transform::{Transform, TypeId};
+use crate::dst::{Output, OutputId, TransformIdx};
+use crate::transform::{Transform, TypeId};
 use variant_name::VariantName;
 
 /// Identifies a [`Node`] in a [`DST`]. A node can either be a [`Transform`],

--- a/src/aflak_cake/src/export.rs
+++ b/src/aflak_cake/src/export.rs
@@ -10,9 +10,9 @@ use uuid::Uuid;
 use variant_name::VariantName;
 
 use super::ConvertibleVariants;
-use dst::{DSTError, Input, Output, OutputId, TransformIdx, DST};
-use macros::MacroManager;
-use transform::{Algorithm, Transform, Version};
+use crate::dst::{DSTError, Input, Output, OutputId, TransformIdx, DST};
+use crate::macros::MacroManager;
+use crate::transform::{Algorithm, Transform, Version};
 
 /// Trait that defines a function to get a [`Transform`] by its name.
 pub trait NamedAlgorithms<E>: Sized {

--- a/src/aflak_cake/src/lib.rs
+++ b/src/aflak_cake/src/lib.rs
@@ -24,17 +24,17 @@ pub mod macros;
 mod timed;
 mod transform;
 
-pub use boow::Bow;
-pub use cache::Cache;
-pub use dst::{
+pub use crate::cache::Cache;
+pub use crate::dst::{
     compute, DSTError, Input, InputDefaultsMut, InputSlot, LinkIter, MetaTransform, Node, NodeId,
     NodeIter, Output, OutputId, TransformAndDefaults, TransformIdx, DST,
 };
-pub use export::{DeserDST, ImportError, NamedAlgorithms, SerialDST};
-pub use future::Task;
+pub use crate::export::{DeserDST, ImportError, NamedAlgorithms, SerialDST};
+pub use crate::future::Task;
+pub use crate::timed::Timed;
+pub use crate::transform::*;
+pub use boow::Bow;
 pub use futures::{future::Future, Async};
-pub use timed::Timed;
-pub use transform::*;
 
 pub use self::variant_name::VariantName;
 

--- a/src/aflak_cake/src/macros.rs
+++ b/src/aflak_cake/src/macros.rs
@@ -12,8 +12,8 @@ use super::{
     Algorithm, ConvertibleVariants, InputSlot, Output, Transform, TransformInputSlot, TypeId,
     VariantName, DST,
 };
-use compute::ComputeError;
-use export::{DeserDST, ImportError, NamedAlgorithms};
+use crate::compute::ComputeError;
+use crate::export::{DeserDST, ImportError, NamedAlgorithms};
 
 pub struct MacroHandle<'t, T: 't, E: 't> {
     inner: Arc<RwLock<Macro<'t, T, E>>>,

--- a/src/aflak_cake/src/transform.rs
+++ b/src/aflak_cake/src/transform.rs
@@ -7,8 +7,8 @@ use std::vec;
 use boow::Bow;
 
 use super::ConvertibleVariants;
-use compute::ComputeError;
-use macros::MacroHandle;
+use crate::compute::ComputeError;
+use crate::macros::MacroHandle;
 use variant_name::VariantName;
 
 /// Static string that identifies a transformation.
@@ -93,7 +93,7 @@ where
     T: Clone,
 {
     fn clone(&self) -> Self {
-        use Algorithm::*;
+        use crate::Algorithm::*;
         match *self {
             Function {
                 f,

--- a/src/aflak_cake/tests/algo.rs
+++ b/src/aflak_cake/tests/algo.rs
@@ -9,7 +9,7 @@ extern crate lazy_static;
 extern crate serde;
 
 mod support;
-use support::*;
+use crate::support::*;
 
 #[test]
 fn test_plus1() {

--- a/src/aflak_cake/tests/dst.rs
+++ b/src/aflak_cake/tests/dst.rs
@@ -11,7 +11,7 @@ extern crate serde;
 extern crate ron;
 
 mod support;
-use support::*;
+use crate::support::*;
 
 use aflak_cake::Cache;
 use futures::{future::Future, Async};

--- a/src/aflak_cake/tests/macros.rs
+++ b/src/aflak_cake/tests/macros.rs
@@ -14,7 +14,7 @@ extern crate boow;
 use boow::Bow;
 
 mod support;
-use support::*;
+use crate::support::*;
 
 fn make_macro() -> aflak_cake::macros::MacroHandle<'static, AlgoIO, E> {
     if let &[plus1, minus1, _, _, _] = *TRANSFORMATIONS_REF {

--- a/src/aflak_cake/tests/serialize.rs
+++ b/src/aflak_cake/tests/serialize.rs
@@ -10,7 +10,7 @@ extern crate ron;
 extern crate serde;
 
 mod support;
-use support::*;
+use crate::support::*;
 
 use aflak_cake::export::{DeserTransform, SerialTransform};
 use aflak_cake::macros::MacroManager;

--- a/src/aflak_plot/Cargo.toml
+++ b/src/aflak_plot/Cargo.toml
@@ -3,6 +3,7 @@ name = "aflak_plot"
 version = "0.0.3"
 authors = ["Malik Olivier Boussejra <malik@boussejra.com>"]
 description = "Plotting library using imgui made for aflak"
+edition = "2018"
 license = "GPL-3.0-only"
 
 [dependencies]

--- a/src/aflak_plot/src/imshow/image.rs
+++ b/src/aflak_plot/src/imshow/image.rs
@@ -15,7 +15,7 @@ use ndarray::{ArrayBase, ArrayD, ArrayView2, Data, Dimension, Ix2};
 use super::hist;
 use super::lut::ColorLUT;
 use super::{Error, Textures};
-use lims;
+use crate::lims;
 
 fn make_raw_image<S>(
     image: &ArrayBase<S, Ix2>,

--- a/src/aflak_plot/src/imshow/mod.rs
+++ b/src/aflak_plot/src/imshow/mod.rs
@@ -13,10 +13,10 @@ use imgui::{self, TextureId, Ui};
 use imgui_glium_renderer::Texture;
 use ndarray::ArrayD;
 
-use err::Error;
-use interactions;
-use ticks;
-use util;
+use crate::err::Error;
+use crate::interactions;
+use crate::ticks;
+use crate::util;
 
 use super::AxisTransform;
 

--- a/src/aflak_plot/src/lib.rs
+++ b/src/aflak_plot/src/lib.rs
@@ -23,6 +23,6 @@ mod ticks;
 mod units;
 mod util;
 
-pub use err::Error;
-pub use interactions::{Interaction, InteractionId, InteractionIterMut, Value, ValueIter};
-pub use units::AxisTransform;
+pub use crate::err::Error;
+pub use crate::interactions::{Interaction, InteractionId, InteractionIterMut, Value, ValueIter};
+pub use crate::units::AxisTransform;

--- a/src/aflak_primitives/Cargo.toml
+++ b/src/aflak_primitives/Cargo.toml
@@ -3,6 +3,7 @@ name = "aflak_primitives"
 version = "0.0.3"
 authors = ["Malik Olivier Boussejra <malik@boussejra.com>"]
 description = "Define primitive functions for use with aflak"
+edition = "2018"
 license = "GPL-3.0-only"
 
 [dependencies]

--- a/src/aflak_primitives/src/lib.rs
+++ b/src/aflak_primitives/src/lib.rs
@@ -35,8 +35,8 @@ mod precond;
 mod roi;
 mod unit;
 
-pub use roi::ROI;
-pub use unit::{Dimensioned, Unit, WcsArray};
+pub use crate::roi::ROI;
+pub use crate::unit::{Dimensioned, Unit, WcsArray};
 
 use std::error::Error;
 use std::fmt;
@@ -70,7 +70,7 @@ pub enum IOValue {
 
 impl PartialEq for IOValue {
     fn eq(&self, val: &Self) -> bool {
-        use IOValue::*;
+        use crate::IOValue::*;
         match (self, val) {
             (Integer(i1), Integer(i2)) => i1 == i2,
             (Float(f1), Float(f2)) => f1 == f2,
@@ -100,7 +100,7 @@ pub enum IOErr {
 
 impl fmt::Display for IOErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use IOErr::*;
+        use crate::IOErr::*;
 
         match self {
             IoError(e, s) => write!(f, "I/O error! {}. This was caused by '{}'.", s, e),
@@ -227,7 +227,7 @@ Compute off_ratio = 1 - (z - z1) / (z2 - z1), off_ratio_2 = 1 - (z2 - z) / (z2 -
                 1, 0, 0,
                 ratio_from_bands<IOValue, IOErr>(z: Float, z1: Float, z2: Float) -> Float, Float {
                     if !(z1 < z && z < z2) {
-                        use IOErr::UnexpectedInput;
+                        use crate::IOErr::UnexpectedInput;
                         let msg = format!(
                             "wrong magnitude correlation ({} < {} < {})",
                             z1, z, z2

--- a/src/aflak_primitives/src/unit.rs
+++ b/src/aflak_primitives/src/unit.rs
@@ -3,7 +3,7 @@ use std::{fmt, ops};
 use fitrs::{FitsData, Hdu, HeaderValue, WCS};
 use ndarray::{ArrayD, ArrayView1, ArrayView2, IxDyn};
 
-use fits::{FitsArrayReadError, FitsDataToArray};
+use crate::fits::{FitsArrayReadError, FitsDataToArray};
 
 /// A unit of measurement.
 ///

--- a/src/imgui_file_explorer/Cargo.toml
+++ b/src/imgui_file_explorer/Cargo.toml
@@ -3,6 +3,7 @@ name = "imgui_file_explorer"
 version = "0.0.3"
 authors = ["Rikuo Uchiki <dbkn_rikuo@keio.jp>", "Malik Olivier Boussejra <malik@boussejra.com>"]
 description = "File explorer plugin for imgui-rs"
+edition = "2018"
 license = "GPL-3.0-only"
 repository = "https://github.com/aflak-vis/aflak"
 

--- a/src/imgui_file_explorer/README.md
+++ b/src/imgui_file_explorer/README.md
@@ -4,7 +4,6 @@
 
 ## Run
 ```sh
-git submodule update --init --recursive
 cargo run --example test
 ```
 

--- a/src/imgui_glium_support/Cargo.toml
+++ b/src/imgui_glium_support/Cargo.toml
@@ -3,6 +3,7 @@ name = "aflak_imgui_glium_support"
 version = "0.0.3"
 authors = ["Malik Olivier Boussejra <malik@boussejra.com>"]
 description = "Support crate for using glium with imgui, made for aflak project"
+edition = "2018"
 license = "GPL-3.0-only"
 
 [dependencies]

--- a/src/node_editor/Cargo.toml
+++ b/src/node_editor/Cargo.toml
@@ -3,6 +3,7 @@ name = "node_editor"
 version = "0.0.3"
 authors = ["Malik Olivier Boussejra <malik@boussejra.com>"]
 description = "Node editor UI using imgui-rs as backend, made for aflak project"
+edition = "2018"
 license = "GPL-3.0-only"
 
 [dependencies]

--- a/src/node_editor/src/event.rs
+++ b/src/node_editor/src/event.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use cake::{macros, InputSlot, NodeId, Output, Transform, TransformIdx};
+use crate::cake::{macros, InputSlot, NodeId, Output, Transform, TransformIdx};
 
 pub enum RenderEvent<T: 'static, E: 'static> {
     Connect(Output, InputSlot),
@@ -51,7 +51,7 @@ impl<T, E> fmt::Debug for RenderEvent<T, E> {
 
 pub trait ApplyRenderEvent<T, E> {
     fn apply_event(&mut self, ev: RenderEvent<T, E>) {
-        use event::RenderEvent::*;
+        use crate::event::RenderEvent::*;
         match ev {
             Connect(output, input_slot) => self.connect(output, input_slot),
             Disconnect(output, input_slot) => self.disconnect(output, input_slot),

--- a/src/node_editor/src/export.rs
+++ b/src/node_editor/src/export.rs
@@ -2,7 +2,7 @@ use std::error;
 use std::fmt;
 use std::io;
 
-use cake;
+use crate::cake;
 use ron::{de, error as ser_error};
 
 #[derive(Debug)]

--- a/src/node_editor/src/id_stack.rs
+++ b/src/node_editor/src/id_stack.rs
@@ -1,4 +1,4 @@
-use cake::NodeId;
+use crate::cake::NodeId;
 
 /// Trait to get an i32 ID out of the implemented type.
 pub trait GetId {

--- a/src/node_editor/src/layout.rs
+++ b/src/node_editor/src/layout.rs
@@ -1,4 +1,4 @@
-use collections::HashSet;
+use crate::collections::HashSet;
 use std::error::Error;
 
 use imgui::{
@@ -7,15 +7,15 @@ use imgui::{
 };
 use serde::{Deserialize, Serialize};
 
-use cake::{self, InputSlot, Transform, VariantName, DST};
+use crate::cake::{self, InputSlot, Transform, VariantName, DST};
 
-use constant_editor::ConstantEditor;
-use event::RenderEvent;
-use id_stack::GetId;
+use crate::constant_editor::ConstantEditor;
+use crate::event::RenderEvent;
+use crate::id_stack::GetId;
+use crate::node_state::NodeStates;
+use crate::scrolling::Scrolling;
+use crate::vec2::Vec2;
 use imgui_file_explorer::UiFileExplorer;
-use node_state::NodeStates;
-use scrolling::Scrolling;
-use vec2::Vec2;
 
 pub struct NodeEditorLayout<T: 'static, E: 'static> {
     node_states: NodeStates,

--- a/src/node_editor/src/lib.rs
+++ b/src/node_editor/src/lib.rs
@@ -23,13 +23,13 @@ mod vec2;
 
 use std::{collections, error, fmt, fs, io, path};
 
-use cake::Future;
+use crate::cake::Future;
 use imgui::ImString;
 use imgui_file_explorer::UiFileExplorer;
 
-pub use constant_editor::ConstantEditor;
-use event::ApplyRenderEvent;
-use layout::NodeEditorLayout;
+pub use crate::constant_editor::ConstantEditor;
+use crate::event::ApplyRenderEvent;
+use crate::layout::NodeEditorLayout;
 
 /// The node editor instance.
 pub struct NodeEditor<T: 'static, E: 'static> {
@@ -628,7 +628,7 @@ enum InnerEditorError {
 
 impl fmt::Display for InnerEditorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use InnerEditorError::*;
+        use crate::InnerEditorError::*;
         match self {
             IncorrectNodeConnection(e) => write!(f, "{}", e),
             SelfDefiningMacro { name } => write!(f, "Cannot re-use macro '{}' in itself!", name),

--- a/src/node_editor/src/node_state.rs
+++ b/src/node_editor/src/node_state.rs
@@ -1,8 +1,8 @@
 use std::collections::{btree_map, BTreeMap};
 
-use cake;
+use crate::cake;
 
-use vec2::Vec2;
+use crate::vec2::Vec2;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeState {

--- a/src/node_editor/src/scrolling.rs
+++ b/src/node_editor/src/scrolling.rs
@@ -1,4 +1,4 @@
-use vec2::Vec2;
+use crate::vec2::Vec2;
 
 #[derive(Default)]
 pub struct Scrolling {

--- a/src/src/aflak.rs
+++ b/src/src/aflak.rs
@@ -5,15 +5,15 @@ use std::path::PathBuf;
 use glium;
 use imgui::{Condition, ImString, MenuItem, MouseButton, Ui, Window};
 
+use crate::cake::{OutputId, Transform};
+use crate::primitives::{IOErr, IOValue};
 use aflak_plot::imshow::Textures;
-use cake::{OutputId, Transform};
 use node_editor::NodeEditor;
-use primitives::{IOErr, IOValue};
 
-use constant_editor::MyConstantEditor;
-use file_dialog::{FileDialog, FileDialogEvent};
-use layout::{Layout, LayoutEngine};
-use output_window::OutputWindow;
+use crate::constant_editor::MyConstantEditor;
+use crate::file_dialog::{FileDialog, FileDialogEvent};
+use crate::layout::{Layout, LayoutEngine};
+use crate::output_window::OutputWindow;
 
 pub type AflakNodeEditor = NodeEditor<IOValue, IOErr>;
 

--- a/src/src/constant_editor.rs
+++ b/src/src/constant_editor.rs
@@ -1,6 +1,6 @@
+use crate::primitives::{self, IOValue};
 use imgui_file_explorer::{UiFileExplorer, TOP_FOLDER};
 use node_editor::ConstantEditor;
-use primitives::{self, IOValue};
 
 use imgui::{ChildWindow, Id, ImString, Ui};
 

--- a/src/src/file_dialog.rs
+++ b/src/src/file_dialog.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use imgui::{ChildWindow, ComboBox, Condition, ImString, Ui, Window};
 use imgui_file_explorer::UiFileExplorer;
 
-use aflak::AflakNodeEditor;
-use templates;
+use crate::aflak::AflakNodeEditor;
+use crate::templates;
 
 pub struct FileDialog {
     selected_template: usize,

--- a/src/src/main.rs
+++ b/src/src/main.rs
@@ -30,7 +30,7 @@ use std::process;
 
 use node_editor::NodeEditor;
 
-use aflak::Aflak;
+use crate::aflak::Aflak;
 
 const CLEAR_COLOR: [f32; 4] = [0.05, 0.05, 0.05, 1.0];
 

--- a/src/src/output_window/menu_bar.rs
+++ b/src/src/output_window/menu_bar.rs
@@ -10,16 +10,16 @@ use glium;
 use imgui::{MenuItem, TextureId, Ui, Window};
 use owning_ref::ArcRef;
 
+use crate::cake::OutputId;
+use crate::primitives::{
+    self,
+    fitrs::{Fits, Hdu},
+    IOValue, ROI,
+};
 use aflak_plot::{
     imshow::{Textures, UiImage2d},
     plot::UiImage1d,
     AxisTransform, InteractionIterMut, ValueIter,
-};
-use cake::OutputId;
-use primitives::{
-    self,
-    fitrs::{Fits, Hdu},
-    IOValue, ROI,
 };
 
 use super::{AflakNodeEditor, EditableValues, OutputWindow};
@@ -340,7 +340,7 @@ impl MenuBar for primitives::WcsArray {
     where
         F: glium::backend::Facade,
     {
-        use primitives::ndarray::Dimension;
+        use crate::primitives::ndarray::Dimension;
         let ui = &ctx.ui;
         match self.scalar().dim().ndim() {
             0 => {

--- a/src/src/output_window/mod.rs
+++ b/src/src/output_window/mod.rs
@@ -8,16 +8,16 @@ use glium;
 use imgui::{Ui, Window};
 use owning_ref::ArcRef;
 
+use crate::cake::{OutputId, TransformIdx};
+use crate::primitives::{ndarray, IOValue, SuccessOut};
 use aflak_plot::{
     imshow::{self, Textures},
     plot, InteractionId,
 };
-use cake::{OutputId, TransformIdx};
-use primitives::{ndarray, IOValue, SuccessOut};
 
 use self::menu_bar::MenuBar;
 use self::visualizable::{Initializing, Unimplemented, Visualizable};
-use aflak::AflakNodeEditor;
+use crate::aflak::AflakNodeEditor;
 
 #[derive(Default)]
 pub struct OutputWindow {

--- a/src/src/output_window/visualizable.rs
+++ b/src/src/output_window/visualizable.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use imgui::{ImString, TreeNode, Ui, Window};
 
-use cake;
-use primitives::fitrs::Fits;
+use crate::cake;
+use crate::primitives::fitrs::Fits;
 
 pub trait Visualizable {
     fn visualize(&self, ui: &Ui);
@@ -52,7 +52,7 @@ impl Visualizable for Fits {
     fn visualize(&self, ui: &Ui) {
         let mut has_hdus = false;
         for (i, hdu) in self.iter().enumerate() {
-            use primitives::fitrs::HeaderValue::*;
+            use crate::primitives::fitrs::HeaderValue::*;
             use std::borrow::Cow;
 
             has_hdus = true;

--- a/src/src/templates.rs
+++ b/src/src/templates.rs
@@ -820,7 +820,7 @@ pub fn show_fits_cleaning<P: AsRef<Path>>(path: P) -> Cursor<String> {
 
 #[cfg(test)]
 mod test {
-    use aflak::AflakNodeEditor;
+    use crate::aflak::AflakNodeEditor;
 
     use super::{
         show_equivalent_width, show_fits_cleaning, show_frame_and_wave, show_velocity_field,

--- a/src/variant_name/Cargo.toml
+++ b/src/variant_name/Cargo.toml
@@ -3,6 +3,7 @@ name = "variant_name"
 version = "0.0.1"
 authors = ["Malik Olivier Boussejra <malik@boussejra.com>"]
 description = "Trait to extract the name of an enumeration's variants"
+edition = "2018"
 license = "GPL-3.0-only"
 
 [dependencies]

--- a/src/variant_name_derive/Cargo.toml
+++ b/src/variant_name_derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "variant_name_derive"
 version = "0.0.1"
 authors = ["Malik Olivier Boussejra <malik@boussejra.com>"]
 description = "Derive VariantName trait"
+edition = "2018"
 license = "GPL-3.0-only"
 
 [dependencies]


### PR DESCRIPTION
Transition guide: https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html

No issue during transition.

Just run `cargo fix --edition` and everything works!

In addition, we removed the now unused `imgui-rs` submodule (e426bba).