### PR TITLE
Add output node name and refine scrolling

### DIFF
--- a/src/aflak_cake/src/dst/build.rs
+++ b/src/aflak_cake/src/dst/build.rs
@@ -27,7 +27,7 @@ where
             for i in 0..len {
                 let output = Output::new(t_idx, i);
                 if self.edges.contains_key(&output)
-                    || self.outputs.values().any(|&val| Some(output) == val)
+                    || self.outputs.values().any(|(val, _)| Some(output) == *val)
                 {
                     outputs.push(output)
                 }
@@ -109,7 +109,7 @@ where
                         self.disconnect(&output, &input);
                     }
                 }
-                for (_, some_output) in self.outputs.iter_mut() {
+                for (_, (some_output, _)) in self.outputs.iter_mut() {
                     if some_output == &Some(output) {
                         *some_output = None;
                     }
@@ -162,7 +162,9 @@ where
     pub fn attach_output(&mut self, output: Output) -> Result<OutputId, DSTError> {
         if self.output_exists(&output) {
             let idx = self.new_output_id();
-            self.update_output(idx, output);
+            if let Some(Node::Output((_, name))) = self.get_node(&NodeId::Output(idx)) {
+                self.update_output(idx, output, name)
+            }
             Ok(idx)
         } else {
             Err(DSTError::InvalidOutput(format!(
@@ -274,7 +276,7 @@ impl<'t, T: 't, E: 't> DST<'t, T, E> {
             NodeId::Output(ref output_id) => self
                 .outputs
                 .get(output_id)
-                .map(|some_output| Node::Output(some_output.as_ref())),
+                .map(|(some_output, name)| Node::Output((some_output.as_ref(), name.clone()))),
         }
     }
 
@@ -340,8 +342,12 @@ impl<'t, T: 't, E: 't> DST<'t, T, E> {
     }
 
     /// Attach an already registered output somewhere else
-    pub fn update_output(&mut self, output_id: OutputId, output: Output) {
-        self.outputs.insert(output_id, Some(output));
+    pub fn update_output(&mut self, output_id: OutputId, output: Output, name: String) {
+        self.outputs.insert(output_id, (Some(output), name));
+        self.transforms
+            .get_mut(&output.t_idx)
+            .unwrap()
+            .updated_now();
     }
 
     /// Detach output with given ID. Does nothing if output does not exist or
@@ -351,7 +357,11 @@ impl<'t, T: 't, E: 't> DST<'t, T, E> {
         OutputId: Borrow<O>,
         O: Ord,
     {
-        if let Some(output) = self.outputs.get_mut(output_id) {
+        self.transforms
+            .get_mut(&output.t_idx)
+            .unwrap()
+            .updated_now();
+        if let Some((output, _)) = self.outputs.get_mut(output_id) {
             *output = None;
         }
     }

--- a/src/aflak_cake/src/dst/build.rs
+++ b/src/aflak_cake/src/dst/build.rs
@@ -304,6 +304,11 @@ impl<'t, T: 't, E: 't> DST<'t, T, E> {
         None
     }
 
+    pub fn change_output_name(&mut self, id: OutputId, new_name: String) {
+        let mut target = self.outputs.get_mut(&id).unwrap();
+        target.1 = new_name;
+    }
+
     pub(crate) fn inputs_attached_to(&self, output: &Output) -> Option<slice::Iter<Input>> {
         self.edges
             .get(output)
@@ -359,10 +364,6 @@ impl<'t, T: 't, E: 't> DST<'t, T, E> {
         OutputId: Borrow<O>,
         O: Ord,
     {
-        self.transforms
-            .get_mut(&output.t_idx)
-            .unwrap()
-            .updated_now();
         if let Some((output, _)) = self.outputs.get_mut(output_id) {
             *output = None;
         }

--- a/src/aflak_cake/src/dst/build.rs
+++ b/src/aflak_cake/src/dst/build.rs
@@ -328,7 +328,8 @@ impl<'t, T: 't, E: 't> DST<'t, T, E> {
     /// Create a new output not attached and return its Id.
     pub fn create_output(&mut self) -> OutputId {
         let idx = self.new_output_id();
-        self.outputs.insert(idx, None);
+        self.outputs
+            .insert(idx, (None, format!("Output #{}", idx.id())));
         idx
     }
 
@@ -338,7 +339,8 @@ impl<'t, T: 't, E: 't> DST<'t, T, E> {
     /// Use [`DST::create_output`] to have aflak manages resources for you
     /// (that's probably what your want).
     pub(crate) fn create_output_with_id(&mut self, output_id: OutputId) {
-        self.outputs.insert(output_id, None);
+        self.outputs
+            .insert(output_id, (None, format!("Output #{}", output_id.id())));
     }
 
     /// Attach an already registered output somewhere else

--- a/src/aflak_cake/src/dst/compute.rs
+++ b/src/aflak_cake/src/dst/compute.rs
@@ -158,7 +158,7 @@ where
         let t_indices = self.transforms.keys().cloned();
         cache.init(t_indices);
 
-        if let Some(some_output) = self.outputs.get(&output_id) {
+        if let Some((some_output, _)) = self.outputs.get(&output_id) {
             if let Some(output) = some_output {
                 let output = *output;
                 let cache_ref = cache.get_ref();
@@ -311,7 +311,7 @@ where
         output_id: OutputId,
         cache: &mut collections::HashMap<Output, Result<T, Arc<ComputeError<E>>>>,
     ) -> Result<T, Arc<ComputeError<E>>> {
-        if let Some(some_output) = self.outputs.get(&output_id) {
+        if let Some((some_output, _)) = self.outputs.get(&output_id) {
             if let Some(output) = some_output {
                 self._compute_sync(*output, cache)
             } else {

--- a/src/aflak_cake/src/dst/iterators.rs
+++ b/src/aflak_cake/src/dst/iterators.rs
@@ -164,7 +164,7 @@ impl<'a, 't, T, E> Iterator for TransformIterator<'a, 't, T, E> {
 /// Iterate over a tuple ([`NodeId`], [`Node`]).
 pub struct NodeIter<'a, 't: 'a, T: 't, E: 't> {
     transforms: TransformIterator<'a, 't, T, E>,
-    outputs: btree_map::Iter<'a, OutputId, Option<Output>>,
+    outputs: btree_map::Iter<'a, OutputId, (Option<Output>, String)>,
 }
 
 /// Iterate over nodes.
@@ -189,7 +189,7 @@ impl<'a, 't, T, E> Iterator for NodeIter<'a, 't, T, E> {
 /// input slot of an output node.
 pub struct LinkIter<'a> {
     edges: EdgeIterator<'a>,
-    outputs: btree_map::Iter<'a, OutputId, Option<Output>>,
+    outputs: btree_map::Iter<'a, OutputId, (Option<Output>, String)>,
 }
 
 impl<'a> LinkIter<'a> {

--- a/src/aflak_cake/src/dst/mod.rs
+++ b/src/aflak_cake/src/dst/mod.rs
@@ -30,7 +30,7 @@ pub use self::node::{Node, NodeId};
 pub struct DST<'t, T: 't, E: 't> {
     transforms: BTreeMap<TransformIdx, MetaTransform<'t, T, E>>,
     edges: BTreeMap<Output, InputList>,
-    outputs: BTreeMap<OutputId, Option<Output>>,
+    outputs: BTreeMap<OutputId, (Option<Output>, String)>,
 }
 
 impl<'t, T, E> Clone for DST<'t, T, E>

--- a/src/aflak_cake/src/dst/mod.rs
+++ b/src/aflak_cake/src/dst/mod.rs
@@ -357,8 +357,8 @@ where
     E: 't,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for (output_id, output) in self.outputs_iter() {
-            writeln!(f, "{:?}", output_id)?;
+        for (output_id, (output, name)) in self.outputs_iter() {
+            writeln!(f, "{:?} name:{:?}", output_id, name)?;
             if let Some(output) = output {
                 self.write_output(f, 1, output)?;
             } else {

--- a/src/aflak_cake/src/dst/node.rs
+++ b/src/aflak_cake/src/dst/node.rs
@@ -18,7 +18,7 @@ pub enum Node<'a, 't: 'a, T: 't, E: 't> {
     Transform(&'a Transform<'t, T, E>),
     /// [`Output`] is `None` when there is an [`OutputId`] not connected to any
     /// [`Output`].
-    Output(Option<&'a Output>),
+    Output((Option<&'a Output>, String)),
 }
 
 impl<'a, 't, T, E> Node<'a, 't, T, E>

--- a/src/aflak_cake/src/dst/node.rs
+++ b/src/aflak_cake/src/dst/node.rs
@@ -41,7 +41,9 @@ impl<'a, 't, T: VariantName, E> Node<'a, 't, T, E> {
             (Node::Transform(t), NodeId::Transform(t_idx)) => {
                 format!("#{} {}", t_idx.id(), t.name())
             }
-            (Node::Output(_), NodeId::Output(output_id)) => format!("Output #{}", output_id.id()),
+            (Node::Output((_, name)), NodeId::Output(output_id)) => {
+                format!("Output #{} {}", output_id.id(), name.clone())
+            }
             (Node::Transform(_), node_id) => panic!(
                 "Node and NodeId do not agree on their types. Got a Node::Transform with Id {:?}.",
                 node_id

--- a/src/aflak_cake/src/export.rs
+++ b/src/aflak_cake/src/export.rs
@@ -177,7 +177,7 @@ impl<T> DeserTransform<T> {
 pub struct SerialDST<'d, T: 'd> {
     transforms: Vec<(&'d TransformIdx, SerialMetaTransform<'d, T>)>,
     edges: Vec<(&'d Output, &'d Input)>,
-    outputs: Vec<(&'d OutputId, &'d Option<Output>)>,
+    outputs: Vec<(&'d OutputId, &'d Option<Output>, String)>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -217,7 +217,7 @@ where
 pub struct DeserDST<T> {
     transforms: Vec<(TransformIdx, DeserMetaTransform<T>)>,
     edges: Vec<(Output, Input)>,
-    outputs: Vec<(OutputId, Option<Output>)>,
+    outputs: Vec<(OutputId, Option<Output>, String)>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/aflak_cake/src/export.rs
+++ b/src/aflak_cake/src/export.rs
@@ -206,7 +206,10 @@ where
                 })
                 .collect(),
             edges: dst.edges_iter().collect(),
-            outputs: dst.outputs_iter().collect(),
+            outputs: dst
+                .outputs_iter()
+                .map(|(output_id, (some_output, name))| (output_id, some_output, name.clone()))
+                .collect(),
         }
     }
 }
@@ -251,7 +254,7 @@ impl<T> DeserDST<T> {
                 .collect(),
             outputs: dst
                 .outputs_iter()
-                .map(|(ouput_id, some_output)| (*ouput_id, *some_output))
+                .map(|(output_id, (some_output, name))| (*output_id, *some_output, name.clone()))
                 .collect(),
         }
     }
@@ -314,10 +317,10 @@ where
                 )
             })?;
         }
-        for (output_id, some_output) in self.outputs {
+        for (output_id, some_output, name) in self.outputs {
             dst.create_output_with_id(output_id);
             if let Some(output) = some_output {
-                dst.update_output(output_id, output);
+                dst.update_output(output_id, output, name);
             }
         }
         Ok(dst)

--- a/src/aflak_cake/src/macros.rs
+++ b/src/aflak_cake/src/macros.rs
@@ -210,7 +210,7 @@ impl<'t, T, E> Macro<'t, T, E> {
     {
         self.dst
             .outputs_iter()
-            .map(|(_, some_output)| {
+            .map(|(_, (some_output, _))| {
                 if let Some(output) = some_output {
                     let t = self.dst.get_transform(output.t_idx).unwrap();
                     t.outputs()[output.index()]
@@ -278,7 +278,9 @@ impl<'t, T, E> Macro<'t, T, E> {
             let t_idx = dst.add_owned_transform(Transform::new_constant((*arg).clone()));
             let output = Output::new(t_idx, 0);
             match input.slot {
-                InputSlot::Output(output_id) => dst.update_output(output_id, output),
+                InputSlot::Output(output_id) => {
+                    dst.update_output(output_id, output, "".to_string())
+                }
                 InputSlot::Transform(input) => {
                     if let Err(e) = dst.connect(output, input) {
                         unimplemented!("Type error: {}", e);

--- a/src/node_editor/examples/minimal.rs
+++ b/src/node_editor/examples/minimal.rs
@@ -231,7 +231,7 @@ fn main() {
 
         // Do something with outputs... For example, show them in a new imgui window
         let outputs = editor.outputs();
-        for output in outputs {
+        for (output, _) in outputs {
             let window_name = ImString::new(format!("Output #{}", output.id()));
             imgui::Window::new(&window_name)
                 .size([400.0, 400.0], imgui::Condition::FirstUseEver)

--- a/src/node_editor/src/event.rs
+++ b/src/node_editor/src/event.rs
@@ -20,6 +20,7 @@ pub enum RenderEvent<T: 'static, E: 'static> {
     AddNewMacro,
     AddMacro(macros::MacroHandle<'static, T, E>),
     EditNode(NodeId),
+    ChangeOutputName(NodeId, String),
 }
 
 impl<T, E> fmt::Debug for RenderEvent<T, E> {
@@ -45,6 +46,9 @@ impl<T, E> fmt::Debug for RenderEvent<T, E> {
             AddNewMacro => write!(f, "AddNewMacro"),
             AddMacro(handle) => write!(f, "AddMacro(id={}, name={:?})", handle.id(), handle.name()),
             EditNode(node_id) => write!(f, "EditNode({:?})", node_id),
+            ChangeOutputName(node_id, name) => {
+                write!(f, "ChangeOutputName(id={:?}, name={})", node_id, name)
+            }
         }
     }
 }
@@ -70,6 +74,7 @@ pub trait ApplyRenderEvent<T, E> {
             AddNewMacro => self.add_new_macro(),
             AddMacro(handle) => self.add_macro(handle),
             EditNode(node_id) => self.edit_node(node_id),
+            ChangeOutputName(node_id, name) => self.change_output_name(node_id, name),
         }
     }
 
@@ -86,4 +91,5 @@ pub trait ApplyRenderEvent<T, E> {
     fn add_new_macro(&mut self);
     fn add_macro(&mut self, handle: macros::MacroHandle<'static, T, E>);
     fn edit_node(&mut self, node: NodeId);
+    fn change_output_name(&mut self, node_id: NodeId, name: String);
 }

--- a/src/node_editor/src/layout.rs
+++ b/src/node_editor/src/layout.rs
@@ -961,6 +961,15 @@ where
                 if changed {
                     *handle.name_mut() = out.to_str().to_owned();
                 }
+            } else if let Some(cake::Node::Output((_, name))) = dst.get_node(id) {
+                ui.text(format!("Output #{}", -id.id()));
+                ui.same_line(0.0);
+                let mut out = ImString::with_capacity(1024);
+                out.push_str(&name);
+                let changed = ui.input_text(im_str!(""), &mut out).build();
+                if changed {
+                    events.push(RenderEvent::ChangeOutputName(*id, out.to_string()));
+                }
             } else {
                 // Show node name
                 ui.text(&node_name);

--- a/src/node_editor/src/layout.rs
+++ b/src/node_editor/src/layout.rs
@@ -424,8 +424,9 @@ where
                 // Scroll
                 if self.drag_node.is_none()
                     && self.creating_link.is_none()
-                    && (ui.io().key_ctrl || ui.io().key_alt)
-                    && ui.is_mouse_dragging(MouseButton::Left)
+                    && (((ui.io().key_ctrl || ui.io().key_alt)
+                        && ui.is_mouse_dragging(MouseButton::Left))
+                        || ui.is_mouse_dragging(MouseButton::Middle))
                 {
                     ui.set_mouse_cursor(Some(MouseCursor::ResizeAll));
                     let delta = Vec2(0.0, 0.0) - ui.io().mouse_delta.into();

--- a/src/node_editor/src/layout.rs
+++ b/src/node_editor/src/layout.rs
@@ -35,7 +35,7 @@ pub struct NodeEditorLayout<T: 'static, E: 'static> {
     import_opened: bool,
     pub import_path: Option<std::path::PathBuf>,
     pub is_macro: bool,
-
+    adding_new_node_pos: Option<Vec2>,
     // Used at runtime to aggregate events
     events: Vec<RenderEvent<T, E>>,
 }
@@ -60,7 +60,7 @@ impl<T, E> Default for NodeEditorLayout<T, E> {
             import_opened: false,
             import_path: None,
             is_macro: false,
-
+            adding_new_node_pos: None,
             events: vec![],
         }
     }
@@ -110,15 +110,25 @@ where
                 let offset = win_pos - scroll;
                 let mouse_pos: Vec2 = ui.io().mouse_pos.into();
                 mouse_pos * 0.7 - offset
+            } else if let Some(pos) = self.adding_new_node_pos {
+                scroll + pos
             } else {
                 scroll + Vec2(30.0, 30.0)
             };
             self.node_states.init_node(&idx, clue);
         }
+        let mut scroll_target_node_pos_size: Option<(Vec2, Vec2)> = None;
         if self.show_left_pane {
-            self.render_left_pane(ui, dst);
+            self.render_left_pane(ui, dst, &mut scroll_target_node_pos_size);
         }
-        self.render_graph_node(ui, dst, addable_nodes, addable_macros, constant_editor);
+        self.render_graph_node(
+            ui,
+            dst,
+            addable_nodes,
+            addable_macros,
+            constant_editor,
+            &mut scroll_target_node_pos_size,
+        );
 
         if ui.is_window_focused_with_flags(WindowFocusedFlags::CHILD_WINDOWS)
             && !ui.io().want_capture_keyboard
@@ -134,7 +144,12 @@ where
         ::std::mem::replace(&mut self.events, vec![])
     }
 
-    fn render_left_pane(&mut self, ui: &Ui, dst: &DST<'static, T, E>) {
+    fn render_left_pane(
+        &mut self,
+        ui: &Ui,
+        dst: &DST<'static, T, E>,
+        scroll_target_node_pos_size: &mut Option<(Vec2, Vec2)>,
+    ) {
         const LEFT_PANE_DEFAULT_RELATIVE_WIDTH: f32 = 0.2;
         let window_size = Vec2::new(ui.window_size());
         let pane_width = *self
@@ -151,7 +166,7 @@ where
                     .build(&ui)
                 {
                     ui.separator();
-                    self.show_node_list(ui, dst);
+                    self.show_node_list(ui, dst, scroll_target_node_pos_size);
                 }
                 ui.separator();
                 if let Some(node_id) = self.active_node {
@@ -212,7 +227,12 @@ where
         ui.same_line(0.0);
     }
 
-    fn show_node_list(&mut self, ui: &Ui, dst: &DST<'static, T, E>) {
+    fn show_node_list(
+        &mut self,
+        ui: &Ui,
+        dst: &DST<'static, T, E>,
+        scroll_target_node_pos_size: &mut Option<(Vec2, Vec2)>,
+    ) {
         const SCROLL_OVER_NODE_OFFSET: Vec2 = Vec2(-50.0, -50.0);
 
         for (idx, node) in dst.nodes_iter() {
@@ -225,9 +245,10 @@ where
                 }
                 self.node_states.toggle_select(&idx);
                 self.active_node = Some(idx);
-                self.scrolling.set_target(
-                    self.node_states.get_state(&idx, |s| s.pos) + SCROLL_OVER_NODE_OFFSET,
-                )
+                *scroll_target_node_pos_size = Some((
+                    self.node_states.get_state(&idx, |s| s.pos),
+                    self.node_states.get_state(&idx, |s| s.size),
+                ));
             }
             stack.pop(ui);
         }
@@ -240,6 +261,7 @@ where
         addable_nodes: &[&'static Transform<T, E>],
         addable_macros: &cake::macros::MacroManager<'static, T, E>,
         constant_editor: &ED,
+        scroll_target_node_pos_size: &mut Option<(Vec2, Vec2)>,
     ) where
         ED: ConstantEditor<T>,
     {
@@ -342,6 +364,13 @@ where
                 .movable(false)
                 .scrollable(false)
                 .build(ui, || {
+                    if let Some((target_node_pos, target_node_size)) = scroll_target_node_pos_size {
+                        let scroll_region_size = Vec2::from(ui.window_size());
+                        self.scrolling.set_target(
+                            *target_node_pos - scroll_region_size * 0.5 + *target_node_size * 0.5,
+                        );
+                        *scroll_target_node_pos_size = None;
+                    }
                     // TODO: Manage scaling (and font-scaling)
                     self.render_graph_canvas(
                         ui,
@@ -418,6 +447,7 @@ where
                         && win_pos.1 < mouse_pos[1]
                         && mouse_pos[1] < win_pos.1 + canvas_size.1
                     {
+                        self.adding_new_node_pos = Some(Vec2::from(mouse_pos) - win_pos);
                         ui.open_popup(im_str!("add-new-node"));
                     }
                 }

--- a/src/node_editor/src/lib.rs
+++ b/src/node_editor/src/lib.rs
@@ -530,6 +530,11 @@ where
             }
         }
     }
+    fn change_output_name(&mut self, node_id: cake::NodeId, name: String) {
+        if let cake::NodeId::Output(output_id) = node_id {
+            self.dst.change_output_name(output_id, name);
+        }
+    }
 }
 
 impl<T, E> ApplyRenderEvent<T, E> for InnerNodeEditor<T, E>
@@ -628,6 +633,13 @@ where
     }
     fn edit_node(&mut self, _: cake::NodeId) {
         unreachable!("Macro can only be edited in NodeEditor's context!");
+    }
+    fn change_output_name(&mut self, node_id: cake::NodeId, name: String) {
+        let mut lock = self.handle.write();
+        let dst = lock.dst_mut();
+        if let cake::NodeId::Output(output_id) = node_id {
+            dst.change_output_name(output_id, name);
+        }
     }
 }
 

--- a/src/node_editor/src/lib.rs
+++ b/src/node_editor/src/lib.rs
@@ -200,11 +200,11 @@ where
     }
 
     /// Get all the outputs defined in the node editor.
-    pub fn outputs(&self) -> Vec<cake::OutputId> {
+    pub fn outputs(&self) -> Vec<(cake::OutputId, String)> {
         self.dst
             .outputs_iter()
-            .filter(|(_, some_output)| some_output.is_some())
-            .map(|(id, _)| *id)
+            .filter(|(_, (some_output, _))| some_output.is_some())
+            .map(|(id, (_, name))| (*id, name.clone()))
             .collect()
     }
 
@@ -450,7 +450,13 @@ where
                     self.error_stack.push(Box::new(e));
                 }
             }
-            cake::InputSlot::Output(output_id) => self.dst.update_output(output_id, output),
+            cake::InputSlot::Output(output_id) => {
+                if let Some(cake::Node::Output((_, name))) =
+                    self.dst.get_node(&cake::NodeId::Output(output_id))
+                {
+                    self.dst.update_output(output_id, output, name)
+                }
+            }
         }
     }
     fn disconnect(&mut self, output: cake::Output, input_slot: cake::InputSlot) {
@@ -541,7 +547,13 @@ where
                         .push(InnerEditorError::IncorrectNodeConnection(e));
                 }
             }
-            cake::InputSlot::Output(output_id) => dst.update_output(output_id, output),
+            cake::InputSlot::Output(output_id) => {
+                if let Some(cake::Node::Output((_, name))) =
+                    dst.get_node(&cake::NodeId::Output(output_id))
+                {
+                    dst.update_output(output_id, output, name)
+                }
+            }
         }
     }
     fn disconnect(&mut self, output: cake::Output, input_slot: cake::InputSlot) {

--- a/src/src/aflak.rs
+++ b/src/src/aflak.rs
@@ -114,8 +114,10 @@ impl Aflak {
         let outputs = self.node_editor.outputs();
         let display_size = ui.io().display_size;
         for output in outputs {
-            let output_window = self.output_windows.entry(output).or_default();
-            let window_name = ImString::new(format!("Output #{}", output.id()));
+            let output_id = output.0;
+            let output_name = output.1;
+            let output_window = self.output_windows.entry(output_id).or_default();
+            let window_name = ImString::new(format!("{}###{:?}", output_name, output_id));
             let mut window = Window::new(&window_name);
             if let Some(Layout { position, size }) = self
                 .layout_engine
@@ -125,8 +127,14 @@ impl Aflak {
                     .position(position, Condition::FirstUseEver)
                     .size(size, Condition::FirstUseEver);
             }
-            let new_errors =
-                output_window.draw(ui, output, window, &mut self.node_editor, gl_ctx, textures);
+            let new_errors = output_window.draw(
+                ui,
+                output_id,
+                window,
+                &mut self.node_editor,
+                gl_ctx,
+                textures,
+            );
             self.error_alerts.extend(new_errors);
         }
     }

--- a/src/src/templates.rs
+++ b/src/src/templates.rs
@@ -90,11 +90,11 @@ pub fn show_frame_and_wave<P: AsRef<Path>>(path: P) -> Cursor<String> {
                 ((1), Some((
                     t_idx: (4),
                     output_i: (0),
-                ))),
+                )), "Spectrum"),
                 ((2), Some((
                     t_idx: (5),
                     output_i: (0),
-                ))),
+                )), "Sliced Plane"),
             ],
         ),
         subs: [
@@ -366,15 +366,15 @@ pub fn show_equivalent_width<P: AsRef<Path>>(path: P) -> Cursor<String> {
                 ((6), Some((
                     t_idx: (19),
                     output_i: (0),
-                ))),
+                )), "Average of On-band"),
                 ((7), Some((
                     t_idx: (22),
                     output_i: (0),
-                ))),
+                )), "Linear composited of Off-band"),
                 ((8), Some((
                     t_idx: (26),
                     output_i: (0),
-                ))),
+                )), "EW Map"),
             ],
         ),
         subs: [
@@ -569,11 +569,11 @@ pub fn show_velocity_field<P: AsRef<Path>>(path: P) -> Cursor<String> {
                 ((1), Some((
                     t_idx: (6),
                     output_i: (0),
-                ))),
+                )), "VF Map using argminmax"),
                 ((2), Some((
                     t_idx: (7),
                     output_i: (0),
-                ))),
+                )), "VF Map using centroid"),
             ],
         ),
         subs: [
@@ -732,15 +732,15 @@ pub fn show_fits_cleaning<P: AsRef<Path>>(path: P) -> Cursor<String> {
                 ((1), Some((
                     t_idx: (4),
                     output_i: (0),
-                ))),
+                )), "Spectrum"),
                 ((2), Some((
                     t_idx: (6),
                     output_i: (0),
-                ))),
+                )), "Sliced Plane"),
                 ((3), Some((
                     t_idx: (2),
                     output_i: (0),
-                ))),
+                )), "FITS Headers"),
             ],
         ),
         subs: [


### PR DESCRIPTION
Output node に対して，Macro と同様に名前を設定できるようにしました．
- https://github.com/aflak-vis/aflak/commit/54ef55a99037dce01a53fc50f46ae1b596e0b375
- https://github.com/aflak-vis/aflak/commit/97bd85fc6443ed638dfc5212887c3ae27bb71add
- https://github.com/aflak-vis/aflak/commit/3dc012b36ddb89823e91d0a38ffe4e265d6ae3e8
- https://github.com/aflak-vis/aflak/commit/f0cd53c4b438dd37ef48c3f7f21119b373e4ec7d
- https://github.com/aflak-vis/aflak/commit/5aafe15b1aa8e5e4dd244608098fffc71ddb4527
- https://github.com/aflak-vis/aflak/commit/ac5674be9cbb23b7583e6b9d5ad66e66c4a1855d
- https://github.com/aflak-vis/aflak/commit/586084c43ba058ed8c0800303f83e493e56c525e
- https://github.com/aflak-vis/aflak/commit/629483694e4585e3420cd72b250108175d4155f5
- https://github.com/aflak-vis/aflak/commit/462eac6e80b6988f13702cc0ef13bf80d369108f

ノードエディタのマウス中央ボタン押し込みによるドラッグに対応しました．
- https://github.com/aflak-vis/aflak/commit/65170e25ff2cc85b2ffb0d5c844b4c82b24c3a21

ノードリストからノードをクリックした際にエディタの中央にノードがスクロールするようにしました．
また，ノードを追加する際に右クリックした場所にノードを追加するようにしました．
- https://github.com/aflak-vis/aflak/commit/ee9f4441f357acba5de256ecef8263ad26626b21

問題なければ週末にマージ予定です．